### PR TITLE
Lint role meta files

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -2,7 +2,6 @@
 exclude_paths:
   - .ansible/roles
   - .venv
-  - meta
   - molecule
 parseable: true
 skip_list:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: Ableton AG
   description: Installs sccache compiler cache
   license: MIT
-  min_ansible_version: 2.10
+  min_ansible_version: "2.10"
   role_name: sccache
 
   galaxy_tags:
@@ -25,4 +25,4 @@ galaxy_info:
         - all
 
 dependencies:
-  - ableton.pkg_mgr_path
+  - role: "ableton.pkg_mgr_path"


### PR DESCRIPTION
We have previously avoided linting these files, but ansible-lint 6.2.x has some useful features for them, so we should no longer skip them.